### PR TITLE
🖌️ Fix styling

### DIFF
--- a/about.md
+++ b/about.md
@@ -5,21 +5,20 @@ title: "❓ About"
 GeoJupyter is a collaboration between many communities and organizations, including but
 not limited to:
 
-* The [Jupyter](https://jupyter.org/) community
-* [QuantStack](https://quantstack.net/)
-* [2i2c](https://2i2c.org/)
-* [Development Seed](https://developmentseed.org/)
-* [Clark University Center for Geospatial Analytics](https://www.clarku.edu/centers/geospatial-analytics/)
-* [Berkeley Institute for Data Science](https://bids.berkeley.edu/)
-* [The Eric & Wendy Schmidt Center for Data Science and Environment at UC Berkeley](https://dse.berkeley.edu/)
+- The [Jupyter](https://jupyter.org/) community
+- [QuantStack](https://quantstack.net/)
+- [2i2c](https://2i2c.org/)
+- [Development Seed](https://developmentseed.org/)
+- [Clark University Center for Geospatial Analytics](https://www.clarku.edu/centers/geospatial-analytics/)
+- [Berkeley Institute for Data Science](https://bids.berkeley.edu/)
+- [The Eric & Wendy Schmidt Center for Data Science and Environment at UC Berkeley](https://dse.berkeley.edu/)
 
 _Please [open an issue in GitHub](https://github.com/geojupyter/geojupyter.org/issues/new) if you'd like to be represented on this list_.
-
 
 ## Current status: Idea generation and development
 
 [QuantStack](https://quantstack.net/) is developing
-[JupyterGIS](https://github.com/geojupyter/jupytergis), a *collaborative* GIS
+[JupyterGIS](https://github.com/geojupyter/jupytergis), a _collaborative_ GIS
 environment in JupyterLab.
 
 [DSE](https://dse.berkeley.edu/) and the GeoJupyter community are distilling insights from interviewees.
@@ -27,20 +26,16 @@ environment in JupyterLab.
 The GeoJupyter community is [meeting bi-weekly](/blog/20250129-announcing-geojupyter-hackathons) to generate and develop ideas.
 Please see our [hackathon notes blog posts](/blog/#category=Hackathons) to follow our progress!
 
-+++{"kind": "centered"}
 :::{include} call-to-action.md
 :::
-+++
-
 
 ## Next: Community programming, prototyping
 
-* Community meetings
-  * Core meetings
-  * Hackathons
-  * Office hours
-* Prototype minimal use-case focused workflows
-
+- Community meetings
+  - Core meetings
+  - Hackathons
+  - Office hours
+- Prototype minimal use-case focused workflows
 
 ## How you can contribute
 
@@ -51,7 +46,6 @@ please [sign up for an interview](/interviews/sign-up.md)!
 
 Introduce yourself in our
 [community chat space on Zulip](https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter/topic/Welcome)!
-
 
 :::{note} © 2025 GeoJupyter Contributors.
 

--- a/call-to-action.md
+++ b/call-to-action.md
@@ -4,5 +4,5 @@
 
 % Til that lands, needs to be done more manually.
 
-<span class="btn btn-primary"> [Join a hackathon](blog/20250129-announcing-geojupyter-hackathons/index.md)
-</span> <span class="btn btn-primary"> [Join the community chat on Zulip](https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter) </span> <span class="btn btn-secondary">[Sign up for an interview](interviews/sign-up.md)</span>
+{button}`Join a hackathon<blog/20250129-announcing-geojupyter-hackathons/index.md>` {button}`Join the community chat on Zulip<https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter>` {button}`Sign up for an interview<interviews/sign-up.md>`
+% TODO: secondary button

--- a/elevator-pitch.md
+++ b/elevator-pitch.md
@@ -9,6 +9,6 @@ We aim to combine the **approachability** and **playfulness** of desktop GIS too
 **flexibility** and **reproducibility** of coding-driven GIS methods, and the
 **collaborative** and **storytelling** power of Jupyter to enable more researchers,
 educators, and learners to confidently engage with geospatial data.
-% END-SUB
+% END-DESC
 
 <hr style="width:50%; margin: auto" />

--- a/elevator-pitch.md
+++ b/elevator-pitch.md
@@ -1,7 +1,7 @@
 <hr style="width:50%; margin: auto" />
 
 % BEGIN-SUB
-GeoJupyter is an open and collaborative community-driven effort to reimagine **<span class="jupyter-orange">geospatial interactive computing</span>** experiences for education, research, and industry.
+GeoJupyter is an open and collaborative community-driven effort to reimagine **{orange}`geospatial interactive computing`** experiences for education, research, and industry.
 % END-SUB
 
 % BEGIN-DESC

--- a/elevator-pitch.md
+++ b/elevator-pitch.md
@@ -1,10 +1,14 @@
 <hr style="width:50%; margin: auto" />
 
-GeoJupyter is an open and collaborative community-driven effort to reimagine <span class="jupyter-orange">**geospatial interactive computing**</span> experiences for education, research, and industry.
+% BEGIN-SUB
+GeoJupyter is an open and collaborative community-driven effort to reimagine **<span class="jupyter-orange">geospatial interactive computing</span>** experiences for education, research, and industry.
+% END-SUB
 
+% BEGIN-DESC
 We aim to combine the **approachability** and **playfulness** of desktop GIS tools, the
 **flexibility** and **reproducibility** of coding-driven GIS methods, and the
 **collaborative** and **storytelling** power of Jupyter to enable more researchers,
 educators, and learners to confidently engage with geospatial data.
+% END-SUB
 
 <hr style="width:50%; margin: auto" />

--- a/index.md
+++ b/index.md
@@ -7,34 +7,36 @@ site:
   hide_toc: true
 ---
 
++++ {"kind": "split-image"}
 % FIXME: alignment?? Centering the image seems to be using a different page width as centereing the content below, so the logo and text are misaligned.
 
-:::{image} https://avatars.githubusercontent.com/u/170677547?s=400&u=03648f729acc1a0f82ed15246feb7a77c1fcced7&v=4
+## GeoJupyter
+
+:::{image} https://picsum.photos/id/1015/1024/512/
 :alt: Earth Logo
-:width: 40%
 
 :::
-
-+++ {"kind": "centered"}
-
-:::{image} https://avatars.githubusercontent.com/u/170677547?s=400&u=03648f729acc1a0f82ed15246feb7a77c1fcced7&v=4
-:alt: Earth Logo
-:width: 40%
-
-:::
-
-# GeoJupyter
 
 :::{include} elevator-pitch.md
+:start-at: BEGIN-SUB
+:end-at: END-SUB
 :::
 
++++ { "kind": "centered" }
+
+## What is GeoJupyter?
+
+:::{include} elevator-pitch.md
+:start-at: BEGIN-DESC
+:end-at: END-DESC
+:::
 
 [_Current status: Idea generation & development_](about.md)
-
 
 :::{include} call-to-action.md
 :::
 
++++
 
 :::{note} © 2025 GeoJupyter Contributors.
 

--- a/myst.yml
+++ b/myst.yml
@@ -7,6 +7,8 @@ project:
   # keywords: []
   # authors: []
   github: https://github.com/geojupyter/geojupyter.org
+  plugins:
+    - plugin.mjs
     
 site:
   template: book-theme

--- a/plugin.mjs
+++ b/plugin.mjs
@@ -1,0 +1,22 @@
+const orangeRole = {
+  name: `orange`,
+  doc: `A role for Jupyter orange text`,
+  body: {
+    type: "myst",
+  },
+  run(data) {
+    const div = {
+      type: "span",
+      style: { color: "#e07330" },
+      children: data.body,
+    };
+    return [div];
+  },
+};
+
+const plugin = {
+  name: "GeoJupyter extensions",
+  roles: [orangeRole],
+};
+
+export default plugin;

--- a/styles.css
+++ b/styles.css
@@ -1,23 +1,3 @@
-.card-title {
-  margin-top: 0px;
-  padding-top: 0px;
-}
-
-.center-quote {
-  margin: 15px;
-  padding: 15px;
-
-  font-style: italic;
-  text-align: center;
-}
-
 .jupyter-orange {
   color: #f37636;
-}
-
-.emoji-decoration-left {
-  font-size: 2rem;
-  line-height: 1;
-  text-align: center;
-  margin-right: 20px;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,3 @@
-@import url('https://stackpath.bootstrapcdn.com/bootswatch/4.5.2/spacelab/bootstrap.min.css');
-
-/* Remove underline from links that are styled as buttons */
-a.btn {
-  text-decoration: none;
-}
-
-a.btn:hover {
-  text-decoration: none;
-}
-
-
-/* css styles */
-
 .card-title {
   margin-top: 0px;
   padding-top: 0px;


### PR DESCRIPTION
This PR:
1. Removes most of the custom CSS that was conflicting with MyST's base styles,
2. Uses more of the landing-page machinery as-designed
3. Adds a stock split-image on the home page
4. Adds a custom plugin to enable orange text in markup.

It's not the end-product, but it fixes dark mode and improves the visual style of the main page.

![image](https://github.com/user-attachments/assets/490fddaf-a617-4416-b842-277287558ce5)


<!-- readthedocs-preview geojupyter start -->
---
:mag: Preview: https://geojupyter--1.org.readthedocs.build/en/1/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter end -->